### PR TITLE
BUG 1768938: Add support for min_tx_rate for SR-IOV VFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,10 @@ echo 8 > /sys/class/net/enp2s0f0/device/sriov_numvfs
 * `spoofchk` (string, optional): turn packet spoof checking on or off for the VF
 * `trust` (string, optional): turn trust setting on or off for the VF
 * `link_state` (string, optional): enforce link state for the VF. Allowed values: auto, enable, disable. Note that driver support may differ for this feature. For example, `i40e` is known to work but `igb` doesn't.
-* `max_tx_rate` (int, optional): change the allowed maximum transmit bandwidth, in Mbps, for the VF. 
-Setting this to 0 disables rate limiting.
+* `min_tx_rate` (int, optional): change the allowed minimum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting. The min_tx_rate value should be <= max_tx_rate. Support of this feature depends on NICs and drivers.
 
+* `max_tx_rate` (int, optional): change the allowed maximum transmit bandwidth, in Mbps, for the VF. 
+Setting this to 0 disables rate limiting. 
 
 ### Using DPDK drivers:
 If this plugin is used with a VF bound to a dpdk driver then the IPAM configuration will be ignored.
@@ -226,7 +227,8 @@ EOF
     "type": "sriov",
     "deviceID": "0000:03:02.0",
     "vlan": 1000,
-    "max_tx_rate": 100,
+    "min_tx_rate": 100,
+    "max_tx_rate": 200,
     "spoofchk": "off",
     "trust": "on"
     "link_state": "enable"

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -153,13 +153,13 @@ func (_m *MockNetlinkManager) LinkSetName(_a0 netlink.Link, _a1 string) error {
 	return r0
 }
 
-// LinkSetVfTxRate provides a mock function with given fields: _a0, _a1, _a2
-func (_m *MockNetlinkManager) LinkSetVfTxRate(_a0 netlink.Link, _a1 int, _a2 int) error {
-	ret := _m.Called(_a0, _a1, _a2)
+// LinkSetVfRate provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *MockNetlinkManager) LinkSetVfRate(_a0 netlink.Link, _a1 int, _a2 int, _a3 int) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(netlink.Link, int, int) error); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(netlink.Link, int, int, int) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -18,6 +18,7 @@ type NetConf struct {
 	VFID          int
 	HostIFNames   string // VF netdevice name(s)
 	ContIFNames   string // VF names after in the container; used during deletion
+	MinTxRate     *int   `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
 	MaxTxRate     *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting
 	SpoofChk      string `json:"spoofchk,omitempty"`   // on|off
 	Trust         string `json:"trust,omitempty"`      // on|off


### PR DESCRIPTION
Add support for configuring the min_tx_rate when
configured in the net-attach-def.

Note: min_tx_rate is only supported on Mellanox NICs.

For Intel NICs, do not configure min_tx_rate in the
net-attach-def, or, set the value to 0. Any other
config will cause the pod to fail to be created,
"Invalid Argument" in logs.

Signed-off-by: vpickard <vpickard@redhat.com>