### PR TITLE
BUG 1826593: Restore original VF value when needed (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ echo 0 > /sys/class/net/enp2s0f0/device/sriov_numvfs
 echo 8 > /sys/class/net/enp2s0f0/device/sriov_numvfs
 ```
 
+Note: In case spoofchk is enabled for VF, a valid administrative MAC needs to be specified.
+
 ## Configuration reference
 ### Main parameters
 * `name` (string, required): the name of the network

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,21 +2,44 @@ package types
 
 import (
 	"github.com/containernetworking/cni/pkg/types"
+	"github.com/vishvananda/netlink"
 )
+
+// VfState represents the state of the VF
+type VfState struct {
+	HostIFName   string
+	SpoofChk     bool
+	AdminMAC     string
+	EffectiveMAC string
+	Vlan         int
+	VlanQoS      int
+	MinTxRate    int
+	MaxTxRate    int
+	LinkState    uint32
+}
+
+// FillFromVfInfo - Fill attributes according to the provided netlink.VfInfo struct
+func (vs *VfState) FillFromVfInfo(info *netlink.VfInfo) {
+	vs.AdminMAC = info.Mac.String()
+	vs.LinkState = info.LinkState
+	vs.MaxTxRate = int(info.MaxTxRate)
+	vs.MinTxRate = int(info.MinTxRate)
+	vs.Vlan = info.Vlan
+	vs.VlanQoS = info.Qos
+	vs.SpoofChk = info.Spoofchk
+}
 
 // NetConf extends types.NetConf for sriov-cni
 type NetConf struct {
 	types.NetConf
+	OrigVfState   VfState // Stores the original VF state as it was prior to any operations done during cmdAdd flow
 	DPDKMode      bool
 	Master        string
 	MAC           string
-	AdminMAC      string `json:"adminMAC"`
-	EffectiveMAC  string `json:"effectiveMAC"`
-	Vlan          int    `json:"vlan"`
-	VlanQoS       int    `json:"vlanQoS"`
+	Vlan          *int   `json:"vlan"`
+	VlanQoS       *int   `json:"vlanQoS"`
 	DeviceID      string `json:"deviceID"` // PCI address of a VF in valid sysfs format
 	VFID          int
-	HostIFNames   string // VF netdevice name(s)
 	ContIFNames   string // VF names after in the container; used during deletion
 	MinTxRate     *int   `json:"min_tx_rate"`          // Mbps, 0 = disable rate limiting
 	MaxTxRate     *int   `json:"max_tx_rate"`          // Mbps, 0 = disable rate limiting


### PR DESCRIPTION
This commit attempts to sort out (to some extent)
how a VF configuration is restored.

Until today, almost all VF configurations (except MAC)
where restored to some hardcoded value.
These values may not be desired by the system administrator
or may be invalid for some NIC driver implementation.

As an example, The behaviour of A VF where spoofchk is enabled
and admin mac address is zero is not well defined and is left
for the vendor driver implementors to define the behaviour.
This may cause the NIC's embedded switch to block traffic
from the VF, hence a POD will not be able to send traffic on that VF.

Today, when a user does not specify MAC and Spoofchk values in network
configuration will run into the issue described above when the VF is
reused for a POD.

To fix the issue, described above we take a similar approach to
how Administrative MAC is saved and restored today.

This commit:
  1. Defines a new VF state struct which will save VF configurations
     to be used during configuration restoration which shall be saved
     together with the network confguration in cache.
  2. Moves AdminMAC, EffectiveMAC attributes to the new struct
  3. Saves the VF's state during CmdAdd flow
  4. Conditionally restores all values to their saved state during
     ResetVFConfig()
  5. Modifies order when restoring VF confguration to first restore
     spoofchk and then Administrative MAC
  6. Enhances documentation under Mellanox to clarify the spoofchk
     and mac dependency.