### PR TITLE
Bug 1976918: Fix possible dead loop in sriov pod deletion

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -165,7 +165,14 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	netConf, cRefPath, err := config.LoadConfFromCache(args)
 	if err != nil {
-		return err
+		// If cmdDel() fails, cached netconf is cleaned up by
+		// the followed defer call. However, subsequence calls
+		// of cmdDel() from kubelet fail in a dead loop due to
+		// cached netconf doesn't exist.
+		// Return nil when LoadConfFromCache fails since the rest
+		// of cmdDel() code relies on netconf as input argument
+		// and there is no meaning to continue.
+		return nil
 	}
 
 	defer func() {


### PR DESCRIPTION
Kubelet tries to delete pod in a indefinite loop if
cmdDel() fails, in which case, sriov-cni fails to
recover from subsequence cmdDel() calls due to cached
netconf has been cleaned up in the fist cmdDel() call.

This results in sriov pod not being deleted gracefully
and continues in the terminating state until user
interrupts.

Signed-off-by: Zenghui Shi <zshi@redhat.com>