### PR TITLE
OCPBUGS-16246: [release-4.13] Add both hardware and nic mac allocation retry

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -66,6 +67,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if netConf.RuntimeConfig.Mac != "" {
 		netConf.MAC = netConf.RuntimeConfig.Mac
 	}
+
+	// Always use lower case for mac address
+	netConf.MAC = strings.ToLower(netConf.MAC)
 
 	netns, err := ns.GetNS(args.Netns)
 	if err != nil {

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -2,9 +2,6 @@ package sriov
 
 import (
 	"fmt"
-	"net"
-	"time"
-
 	"github.com/containernetworking/plugins/pkg/ns"
 
 	sriovtypes "github.com/k8snetworkplumbingwg/sriov-cni/pkg/types"
@@ -84,29 +81,12 @@ func (s *sriovManager) SetupVF(conf *sriovtypes.NetConf, podifName string, cid s
 	macAddress := linkObj.Attrs().HardwareAddr.String()
 	// 3. Set MAC address
 	if conf.MAC != "" {
-		hwaddr, err := net.ParseMAC(conf.MAC)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse MAC address %s: %v", conf.MAC, err)
-		}
-
 		// Save the original effective MAC address before overriding it
 		conf.OrigVfState.EffectiveMAC = linkObj.Attrs().HardwareAddr.String()
 
-		/* Some NIC drivers (i.e. i40e/iavf) set VF MAC address asynchronously
-		   via PF. This means that while the PF could already show the VF with
-		   the desired MAC address, the netdev VF may still have the original
-		   one. If in this window we issue a netdev VF MAC address set, the driver
-		   will return an error and the pod will fail to create.
-		   Other NICs (Mellanox) require explicit netdev VF MAC address so we
-		   cannot skip this part.
-		   Retry up to 5 times; wait 200 milliseconds between retries
-		*/
-		err = utils.Retry(5, 200*time.Millisecond, func() error {
-			return s.nLink.LinkSetHardwareAddr(linkObj, hwaddr)
-		})
-
+		err = utils.SetVFEffectiveMAC(s.nLink, tempName, conf.MAC)
 		if err != nil {
-			return "", fmt.Errorf("failed to set netlink MAC address to %s: %v", hwaddr, err)
+			return "", fmt.Errorf("failed to set netlink MAC address to %s: %v", conf.MAC, err)
 		}
 		macAddress = conf.MAC
 	}
@@ -169,15 +149,11 @@ func (s *sriovManager) ReleaseVF(conf *sriovtypes.NetConf, podifName string, cid
 			return fmt.Errorf("failed to rename link %s to host name %s: %q", podifName, conf.OrigVfState.HostIFName, err)
 		}
 
-		// reset effective MAC address
 		if conf.MAC != "" {
-			hwaddr, err := net.ParseMAC(conf.OrigVfState.EffectiveMAC)
+			// reset effective MAC address
+			err = utils.SetVFEffectiveMAC(s.nLink, conf.OrigVfState.HostIFName, conf.OrigVfState.EffectiveMAC)
 			if err != nil {
-				return fmt.Errorf("failed to parse original effective MAC address %s: %v", conf.OrigVfState.EffectiveMAC, err)
-			}
-
-			if err = s.nLink.LinkSetHardwareAddr(linkObj, hwaddr); err != nil {
-				return fmt.Errorf("failed to restore original effective netlink MAC address %s: %v", hwaddr, err)
+				return fmt.Errorf("failed to restore original effective netlink MAC address %s: %v", conf.OrigVfState.EffectiveMAC, err)
 			}
 		}
 
@@ -226,13 +202,9 @@ func (s *sriovManager) ApplyVFConfig(conf *sriovtypes.NetConf) error {
 
 	// 2. Set mac address
 	if conf.MAC != "" {
-		hwaddr, err := net.ParseMAC(conf.MAC)
-		if err != nil {
-			return fmt.Errorf("failed to parse MAC address %s: %v", conf.MAC, err)
-		}
-
-		if err = s.nLink.LinkSetVfHardwareAddr(pfLink, conf.VFID, hwaddr); err != nil {
-			return fmt.Errorf("failed to set MAC address to %s: %v", hwaddr, err)
+		// when we restore the original hardware mac address we may get a device or resource busy. so we introduce retry
+		if err := utils.SetVFHardwareMAC(s.nLink, conf.Master, conf.VFID, conf.MAC); err != nil {
+			return fmt.Errorf("failed to set MAC address to %s: %v", conf.MAC, err)
 		}
 	}
 
@@ -342,25 +314,9 @@ func (s *sriovManager) ResetVFConfig(conf *sriovtypes.NetConf) error {
 
 	// Restore the original administrative MAC address
 	if conf.MAC != "" {
-		hwaddr, err := net.ParseMAC(conf.OrigVfState.AdminMAC)
-		if err != nil {
-			return fmt.Errorf("failed to parse original administrative MAC address %s: %v", conf.OrigVfState.AdminMAC, err)
-		}
-
-		/* Some NIC drivers (i.e. i40e/iavf) set VF MAC address asynchronously
-		   via PF. This means that while the PF could already show the VF with
-		   the desired MAC address, the netdev VF may still have the original
-		   one. If in this window we issue a netdev VF MAC address set, the driver
-		   will return an error and the pod will fail to create.
-		   Other NICs (Mellanox) require explicit netdev VF MAC address so we
-		   cannot skip this part.
-		   Retry up to 5 times; wait 200 milliseconds between retries
-		*/
-		err = utils.Retry(5, 200*time.Millisecond, func() error {
-			return s.nLink.LinkSetVfHardwareAddr(pfLink, conf.VFID, hwaddr)
-		})
-		if err != nil {
-			return fmt.Errorf("failed to restore original administrative MAC address %s: %v", hwaddr, err)
+		// when we restore the original hardware mac address we may get a device or resource busy. so we introduce retry
+		if err := utils.SetVFHardwareMAC(s.nLink, conf.Master, conf.VFID, conf.OrigVfState.AdminMAC); err != nil {
+			return fmt.Errorf("failed to restore original administrative MAC address %s: %v", conf.OrigVfState.AdminMAC, err)
 		}
 	}
 

--- a/pkg/sriov/sriov_suite_test.go
+++ b/pkg/sriov/sriov_suite_test.go
@@ -1,11 +1,12 @@
 package sriov
 
 import (
-	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"testing"
+
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 )
 
 func TestConfig(t *testing.T) {

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -1,6 +1,7 @@
 package sriov
 
 import (
+	"github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
 	"net"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -13,23 +14,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
 )
-
-// FakeLink is a dummy netlink struct used during testing
-type FakeLink struct {
-	netlink.LinkAttrs
-}
-
-// type FakeLink struct {
-// 	linkAtrrs *netlink.LinkAttrs
-// }
-
-func (l *FakeLink) Attrs() *netlink.LinkAttrs {
-	return &l.LinkAttrs
-}
-
-func (l *FakeLink) Type() string {
-	return "FakeLink"
-}
 
 var _ = Describe("Sriov", func() {
 	var (
@@ -76,7 +60,7 @@ var _ = Describe("Sriov", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 
-			fakeLink := &FakeLink{netlink.LinkAttrs{
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
 				Index:        1000,
 				Name:         "dummylink",
 				HardwareAddr: fakeMac,
@@ -113,16 +97,23 @@ var _ = Describe("Sriov", func() {
 			expMac, err := net.ParseMAC(netconf.MAC)
 			Expect(err).NotTo(HaveOccurred())
 
-			fakeLink := &FakeLink{netlink.LinkAttrs{
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
 				Index:        1000,
 				Name:         "dummylink",
 				HardwareAddr: fakeMac,
 			}}
 
-			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+			tempLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:        1000,
+				Name:         "temp_1000",
+				HardwareAddr: expMac,
+			}}
+
+			mocked.On("LinkByName", "enp175s6").Return(fakeLink, nil)
+			mocked.On("LinkByName", "temp_1000").Return(tempLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetName", fakeLink, mock.Anything).Return(nil)
-			mocked.On("LinkSetHardwareAddr", fakeLink, expMac).Return(nil)
+			mocked.On("LinkSetHardwareAddr", tempLink, expMac).Return(nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
 			mocked.On("LinkSetUp", fakeLink).Return(nil)
 			mockedPciUtils.On("EnableArpAndNdiscNotify", mock.AnythingOfType("string")).Return(nil)
@@ -150,7 +141,8 @@ var _ = Describe("Sriov", func() {
 				VFID:        0,
 				ContIFNames: "net1",
 				OrigVfState: sriovtypes.VfState{
-					HostIFName: "enp175s6",
+					HostIFName:   "enp175s6",
+					EffectiveMAC: "6e:16:06:0e:b7:e9",
 				},
 			}
 		})
@@ -164,7 +156,10 @@ var _ = Describe("Sriov", func() {
 			}()
 			Expect(err).NotTo(HaveOccurred())
 			mocked := &mocks_utils.NetlinkManager{}
-			fakeLink := &FakeLink{netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
+			fakeMac, err := net.ParseMAC("6e:16:06:0e:b7:e9")
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink", HardwareAddr: fakeMac}}
 
 			mocked.On("LinkByName", netconf.ContIFNames).Return(fakeLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
@@ -190,7 +185,6 @@ var _ = Describe("Sriov", func() {
 				Master:      "enp175s0f1",
 				DeviceID:    "0000:af:06.0",
 				VFID:        0,
-				MAC:         "aa:f3:8d:65:1b:d4",
 				ContIFNames: "net1",
 				OrigVfState: sriovtypes.VfState{
 					HostIFName:   "enp175s6",
@@ -198,7 +192,7 @@ var _ = Describe("Sriov", func() {
 				},
 			}
 		})
-		It("Restores Effective MAC address when provided in netconf", func() {
+		It("Should not restores Effective MAC address when it is not provided in netconf", func() {
 			var targetNetNS ns.NetNS
 			targetNetNS, err := testutils.NewNS()
 			defer func() {
@@ -207,16 +201,46 @@ var _ = Describe("Sriov", func() {
 				}
 			}()
 			Expect(err).NotTo(HaveOccurred())
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
 			mocked := &mocks_utils.NetlinkManager{}
-			fakeLink := &FakeLink{netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
 
 			mocked.On("LinkByName", netconf.ContIFNames).Return(fakeLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
-			origEffMac, err := net.ParseMAC(netconf.OrigVfState.EffectiveMAC)
+			sm := sriovManager{nLink: mocked}
+			err = sm.ReleaseVF(netconf, podifName, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
-			mocked.On("LinkSetHardwareAddr", fakeLink, origEffMac).Return(nil)
+			mocked.AssertExpectations(t)
+		})
+
+		It("Restores Effective MAC address when provided in netconf", func() {
+			netconf.MAC = "aa:f3:8d:65:1b:d4"
+			var targetNetNS ns.NetNS
+			targetNetNS, err := testutils.NewNS()
+			defer func() {
+				if targetNetNS != nil {
+					targetNetNS.Close()
+				}
+			}()
+			Expect(err).NotTo(HaveOccurred())
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
+			mocked := &mocks_utils.NetlinkManager{}
+
+			fakeMac, err := net.ParseMAC("c6:c8:7f:1f:21:90")
+			Expect(err).NotTo(HaveOccurred())
+			tempLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:        1000,
+				Name:         "enp175s6",
+				HardwareAddr: fakeMac,
+			}}
+
+			mocked.On("LinkByName", netconf.ContIFNames).Return(fakeLink, nil)
+			mocked.On("LinkByName", netconf.OrigVfState.HostIFName).Return(tempLink, nil)
+			mocked.On("LinkSetDown", fakeLink).Return(nil)
+			mocked.On("LinkSetHardwareAddr", tempLink, fakeMac).Return(nil)
+			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
 			sm := sriovManager{nLink: mocked}
 			err = sm.ReleaseVF(netconf, podifName, contID, targetNetNS)
 			Expect(err).NotTo(HaveOccurred())
@@ -245,7 +269,7 @@ var _ = Describe("Sriov", func() {
 			fakeMac, err := net.ParseMAC("6e:16:06:0e:b7:e9")
 			Expect(err).NotTo(HaveOccurred())
 
-			fakeLink := &FakeLink{netlink.LinkAttrs{
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
 				Index:        1000,
 				Name:         "dummylink",
 				HardwareAddr: fakeMac,
@@ -281,7 +305,7 @@ var _ = Describe("Sriov", func() {
 		})
 		It("Does not change VF config if it wasnt requested to be changed in netconf", func() {
 			mocked := &mocks_utils.NetlinkManager{}
-			fakeLink := &FakeLink{netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
 
 			mocked.On("LinkByName", netconf.Master).Return(fakeLink, nil)
 			sm := sriovManager{nLink: mocked}
@@ -304,7 +328,7 @@ var _ = Describe("Sriov", func() {
 			netconf = &sriovtypes.NetConf{
 				Master:      "enp175s0f1",
 				DeviceID:    "0000:af:06.0",
-				VFID:        3,
+				VFID:        0,
 				ContIFNames: "net1",
 				MAC:         "d2:fc:22:a7:0d:e8",
 				Vlan:        &vlan,
@@ -328,14 +352,16 @@ var _ = Describe("Sriov", func() {
 			}
 		})
 		It("Restores original VF configurations", func() {
+			origMac, err := net.ParseMAC(netconf.OrigVfState.AdminMAC)
+			Expect(err).NotTo(HaveOccurred())
 			mocked := &mocks_utils.NetlinkManager{}
-			fakeLink := &FakeLink{netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink", Vfs: []netlink.VfInfo{
+				{Mac: origMac},
+			}}}
 
 			mocked.On("LinkByName", netconf.Master).Return(fakeLink, nil)
 			mocked.On("LinkSetVfVlanQos", fakeLink, netconf.VFID, netconf.OrigVfState.Vlan, netconf.OrigVfState.VlanQoS).Return(nil)
 			mocked.On("LinkSetVfSpoofchk", fakeLink, netconf.VFID, netconf.OrigVfState.SpoofChk).Return(nil)
-			origMac, err := net.ParseMAC(netconf.OrigVfState.AdminMAC)
-			Expect(err).NotTo(HaveOccurred())
 			mocked.On("LinkSetVfHardwareAddr", fakeLink, netconf.VFID, origMac).Return(nil)
 			mocked.On("LinkSetVfTrust", fakeLink, netconf.VFID, false).Return(nil)
 			mocked.On("LinkSetVfRate", fakeLink, netconf.VFID, netconf.OrigVfState.MinTxRate, netconf.OrigVfState.MaxTxRate).Return(nil)

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/vishvananda/netlink"
 )
 
 type tmpSysFs struct {
@@ -138,4 +140,21 @@ func RemoveTmpSysFs() error {
 		return err
 	}
 	return nil
+}
+
+// FakeLink is a dummy netlink struct used during testing
+type FakeLink struct {
+	netlink.LinkAttrs
+}
+
+// type FakeLink struct {
+// 	linkAtrrs *netlink.LinkAttrs
+// }
+
+func (l *FakeLink) Attrs() *netlink.LinkAttrs {
+	return &l.LinkAttrs
+}
+
+func (l *FakeLink) Type() string {
+	return "FakeLink"
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -288,6 +288,83 @@ func CleanCachedNetConf(cRefPath string) error {
 	return nil
 }
 
+// SetVFEffectiveMAC will try to set the mac address on a specific VF interface
+//
+// the function will also validate that the mac address was configured as expect
+// it will return an error if it didn't manage to configure the vf mac address
+// or the mac is not equal to the expect one
+// retries 20 times and wait 100 milliseconds
+//
+// Some NIC drivers (i.e. i40e/iavf) set VF MAC address asynchronously
+// via PF. This means that while the PF could already show the VF with
+// the desired MAC address, the netdev VF may still have the original
+// one. If in this window we issue a netdev VF MAC address set, the driver
+// will return an error and the pod will fail to create.
+// Other NICs (Mellanox) require explicit netdev VF MAC address so we
+// cannot skip this part.
+// Retry up to 5 times; wait 200 milliseconds between retries
+func SetVFEffectiveMAC(netLinkManager NetlinkManager, netDeviceName string, macAddress string) error {
+	hwaddr, err := net.ParseMAC(macAddress)
+	if err != nil {
+		return fmt.Errorf("failed to parse MAC address %s: %v", macAddress, err)
+	}
+
+	orgLinkObj, err := netLinkManager.LinkByName(netDeviceName)
+	if err != nil {
+		return err
+	}
+
+	return Retry(20, 100*time.Millisecond, func() error {
+		if err := netLinkManager.LinkSetHardwareAddr(orgLinkObj, hwaddr); err != nil {
+			return err
+		}
+
+		linkObj, err := netLinkManager.LinkByName(netDeviceName)
+		if err != nil {
+			return fmt.Errorf("failed to get netlink device with name %s: %q", orgLinkObj.Attrs().Name, err)
+		}
+		if linkObj.Attrs().HardwareAddr.String() != macAddress {
+			return fmt.Errorf("effective mac address is different from requested one")
+		}
+
+		return nil
+	})
+}
+
+// SetVFHardwareMAC will try to set the hardware mac address on a specific VF ID under a requested PF
+
+// the function will also validate that the mac address was configured as expect
+// it will return an error if it didn't manage to configure the vf mac address
+// or the mac is not equal to the expect one
+// retries 20 times and wait 100 milliseconds
+func SetVFHardwareMAC(netLinkManager NetlinkManager, pfDevice string, vfID int, macAddress string) error {
+	hwaddr, err := net.ParseMAC(macAddress)
+	if err != nil {
+		return fmt.Errorf("failed to parse MAC address %s: %v", macAddress, err)
+	}
+
+	orgLinkObj, err := netLinkManager.LinkByName(pfDevice)
+	if err != nil {
+		return err
+	}
+
+	return Retry(20, 100*time.Millisecond, func() error {
+		if err := netLinkManager.LinkSetVfHardwareAddr(orgLinkObj, vfID, hwaddr); err != nil {
+			return err
+		}
+
+		linkObj, err := netLinkManager.LinkByName(pfDevice)
+		if err != nil {
+			return fmt.Errorf("failed to get netlink device with name %s: %q", orgLinkObj.Attrs().Name, err)
+		}
+		if linkObj.Attrs().Vfs[vfID].Mac.String() != macAddress {
+			return fmt.Errorf("hardware mac address is different from requested one")
+		}
+
+		return nil
+	})
+}
+
 // IsValidMACAddress checks if net.HardwareAddr is a valid MAC address.
 func IsValidMACAddress(addr net.HardwareAddr) bool {
 	invalidMACAddresses := [][]byte{


### PR DESCRIPTION
This commit add a retry function for all the mac address allocation functions.
this is needed because some of the drivers have async mac allocation or get a device or resouce busy errors until the vf device is fully configured on the system so instead of failing the CNI we just wait 100 miliseconds