### PR TITLE
OCPBUGS-26220: build binaries on RHEL8

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,5 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
+# Keep the builder image compatible with the previous EUS (Extended Update Support) rhel version
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 
 COPY . /usr/src/sriov-cni
 


### PR DESCRIPTION
During upgrades, there can be a time slot where sriov binary runs on RHEL8, causing a `GLIBC_2.32' not found` error. Always use a builder image that is compatible with the previous EUS (Extended Update Support) release.