### PR TITLE
Always restore VF admin MAC address on pod teardown

### DIFF
--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -405,8 +405,8 @@ func (s *sriovManager) ResetVFConfig(conf *sriovtypes.NetConf) error {
 		}
 	}
 
-	// Restore the original administrative MAC address
-	if conf.MAC != "" {
+	// Restore the original administrative MAC address if exist in the cached state
+	if conf.OrigVfState.AdminMAC != "" {
 		// when we restore the original hardware mac address we may get a device or resource busy. so we introduce retry
 		if err := utils.SetVFHardwareMAC(s.nLink, conf.Master, conf.VFID, conf.OrigVfState.AdminMAC); err != nil {
 			return fmt.Errorf("failed to restore original administrative MAC address %s: %v", conf.OrigVfState.AdminMAC, err)

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -488,6 +488,39 @@ var _ = Describe("Sriov", func() {
 			mocked.AssertExpectations(t)
 		})
 	})
+	Context("Checking ResetVFConfig function - restore MAC when not set via annotation but present in cached state", func() {
+		var (
+			netconf *sriovtypes.NetConf
+		)
+
+		BeforeEach(func() {
+			netconf = &sriovtypes.NetConf{SriovNetConf: sriovtypes.SriovNetConf{
+				Master:   "enp175s0f1",
+				DeviceID: "0000:af:06.0",
+				VFID:     0,
+				OrigVfState: sriovtypes.VfState{
+					HostIFName: "enp175s6",
+					AdminMAC:   "aa:f3:8d:65:1b:d4",
+				}},
+			}
+		})
+		It("Restores the original administrative MAC address even if conf.MAC is empty", func() {
+			origMac, err := net.ParseMAC(netconf.OrigVfState.AdminMAC)
+			Expect(err).NotTo(HaveOccurred())
+			mocked := &mocks_utils.NetlinkManager{}
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink", Vfs: []netlink.VfInfo{
+				{Mac: origMac},
+			}}}
+
+			mocked.On("LinkByName", netconf.Master).Return(fakeLink, nil)
+			mocked.On("LinkSetVfHardwareAddr", fakeLink, netconf.VFID, origMac).Return(nil)
+
+			sm := sriovManager{nLink: mocked}
+			err = sm.ResetVFConfig(netconf)
+			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertExpectations(t)
+		})
+	})
 	Context("Checking ResetVFConfig function - restore config with user params", func() {
 		var (
 			netconf *sriovtypes.NetConf


### PR DESCRIPTION
Previously, the VF administrative MAC address was only restored during CNI DEL when conf.MAC was set, meaning only when the MAC was explicitly configured via Pod annotation. This left the VF MAC unreset when users configure it through other means (e.g., out-of-band tooling) rather than through the Pod annotation — a common pattern with StatefulSets or Deployments where annotation-based MAC configuration would cause duplicate MAC addresses across replicas.

Change the condition from checking conf.MAC to checking conf.OrigVfState.AdminMAC, so the original MAC is always restored if it was captured in the cached VF state, regardless of how it was originally configured.