### PR TITLE
OCPBUGS-82585: Always restore VF admin MAC address on pod teardown

### DIFF
--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -405,8 +405,8 @@ func (s *sriovManager) ResetVFConfig(conf *sriovtypes.NetConf) error {
 		}
 	}
 
-	// Restore the original administrative MAC address
-	if conf.MAC != "" {
+	// Restore the original administrative MAC address if exist in the cached state
+	if conf.OrigVfState.AdminMAC != "" {
 		// when we restore the original hardware mac address we may get a device or resource busy. so we introduce retry
 		if err := utils.SetVFHardwareMAC(s.nLink, conf.Master, conf.VFID, conf.OrigVfState.AdminMAC); err != nil {
 			return fmt.Errorf("failed to restore original administrative MAC address %s: %v", conf.OrigVfState.AdminMAC, err)

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -212,7 +212,7 @@ func (s *sriovManager) ReleaseVF(conf *sriovtypes.NetConf, podifName string, net
 			return fmt.Errorf("failed to rename link %s to host name %s: %q", podifName, conf.OrigVfState.HostIFName, err)
 		}
 
-		if conf.MAC != "" {
+		if conf.OrigVfState.EffectiveMAC != "" {
 			// reset effective MAC address
 			logging.Debug("Reset effective MAC address",
 				"func", "ReleaseVF",

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -488,6 +488,39 @@ var _ = Describe("Sriov", func() {
 			mocked.AssertExpectations(t)
 		})
 	})
+	Context("Checking ResetVFConfig function - restore MAC when not set via annotation but present in cached state", func() {
+		var (
+			netconf *sriovtypes.NetConf
+		)
+
+		BeforeEach(func() {
+			netconf = &sriovtypes.NetConf{SriovNetConf: sriovtypes.SriovNetConf{
+				Master:   "enp175s0f1",
+				DeviceID: "0000:af:06.0",
+				VFID:     0,
+				OrigVfState: sriovtypes.VfState{
+					HostIFName: "enp175s6",
+					AdminMAC:   "aa:f3:8d:65:1b:d4",
+				}},
+			}
+		})
+		It("Restores the original administrative MAC address even if conf.MAC is empty", func() {
+			origMac, err := net.ParseMAC(netconf.OrigVfState.AdminMAC)
+			Expect(err).NotTo(HaveOccurred())
+			mocked := &mocks_utils.NetlinkManager{}
+			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink", Vfs: []netlink.VfInfo{
+				{Mac: origMac},
+			}}}
+
+			mocked.On("LinkByName", netconf.Master).Return(fakeLink, nil)
+			mocked.On("LinkSetVfHardwareAddr", fakeLink, netconf.VFID, origMac).Return(nil)
+
+			sm := sriovManager{nLink: mocked}
+			err = sm.ResetVFConfig(netconf)
+			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertExpectations(t)
+		})
+	})
 	Context("Checking ResetVFConfig function - restore config with user params", func() {
 		var (
 			netconf *sriovtypes.NetConf

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -331,9 +331,18 @@ var _ = Describe("Sriov", func() {
 
 			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink", HardwareAddr: fakeMac}}
 
+			hostLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
+				Index:        1000,
+				Name:         "enp175s6",
+				HardwareAddr: fakeMac,
+			}}
+
 			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
+			mocked.On("LinkByName", netconf.OrigVfState.HostIFName).Return(hostLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
+			mocked.On("LinkSetHardwareAddr", hostLink, fakeMac).Return(nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
 			mocked.On("LinkSetMTU", fakeLink, 1500).Return(nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
 			sm := sriovManager{nLink: mocked}
@@ -360,8 +369,8 @@ var _ = Describe("Sriov", func() {
 				}},
 			}
 		})
-		It("Should not restores Effective MAC address when it is not provided in netconf", func() {
-			var targetNetNS ns.NetNS
+		It("Should not restore Effective MAC address when EffectiveMAC is not in cached state", func() {
+			netconf.OrigVfState.EffectiveMAC = ""
 			targetNetNS, err := testutils.NewNS()
 			defer func() {
 				if targetNetNS != nil {
@@ -382,9 +391,8 @@ var _ = Describe("Sriov", func() {
 			mocked.AssertExpectations(t)
 		})
 
-		It("Restores Effective MAC address when provided in netconf", func() {
-			netconf.MAC = "aa:f3:8d:65:1b:d4"
-			var targetNetNS ns.NetNS
+		It("Restores Effective MAC address when present in cached state", func() {
+			netconf.OrigVfState.EffectiveMAC = "aa:f3:8d:65:1b:d4"
 			targetNetNS, err := testutils.NewNS()
 			defer func() {
 				if targetNetNS != nil {
@@ -395,18 +403,18 @@ var _ = Describe("Sriov", func() {
 			fakeLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{Index: 1000, Name: "dummylink"}}
 			mocked := &mocks_utils.NetlinkManager{}
 
-			fakeMac, err := net.ParseMAC("c6:c8:7f:1f:21:90")
+			restoreMac, err := net.ParseMAC(netconf.OrigVfState.EffectiveMAC)
 			Expect(err).NotTo(HaveOccurred())
 			tempLink := &utils.FakeLink{LinkAttrs: netlink.LinkAttrs{
 				Index:        1000,
 				Name:         "enp175s6",
-				HardwareAddr: fakeMac,
+				HardwareAddr: restoreMac,
 			}}
 
 			mocked.On("LinkByName", podifName).Return(fakeLink, nil)
 			mocked.On("LinkByName", netconf.OrigVfState.HostIFName).Return(tempLink, nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
-			mocked.On("LinkSetHardwareAddr", tempLink, fakeMac).Return(nil)
+			mocked.On("LinkSetHardwareAddr", tempLink, restoreMac).Return(nil)
 			mocked.On("LinkSetName", fakeLink, netconf.OrigVfState.HostIFName).Return(nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
 			sm := sriovManager{nLink: mocked}


### PR DESCRIPTION
Previously, the VF administrative MAC address was only restored during CNI DEL when conf.MAC was set, meaning only when the MAC was explicitly configured via Pod annotation. This left the VF MAC unreset when users configure it through other means (e.g., out-of-band tooling) rather than through the Pod annotation — a common pattern with StatefulSets or Deployments where annotation-based MAC configuration would cause duplicate MAC addresses across replicas.

Change the condition from checking conf.MAC to checking conf.OrigVfState.AdminMAC, so the original MAC is always restored if it was captured in the cached VF state, regardless of how it was originally configured.