### PR TITLE
CmdDel: handle NSPathNotNSErr to prevent VF leak on corrupted netns

### DIFF
--- a/pkg/cnicommands/cni.go
+++ b/pkg/cnicommands/cni.go
@@ -292,12 +292,14 @@ func CmdDel(args *skel.CmdArgs) error {
 			// if provided path does not exist (e.x. when node was restarted)
 			// plugin should silently return with success after releasing
 			// IPAM resources
-			_, ok := err.(ns.NSPathNotExistErr)
-			if ok {
-				logging.Debug("Exiting as the network namespace does not exists anymore",
+			_, notExist := err.(ns.NSPathNotExistErr)
+			_, notNS := err.(ns.NSPathNotNSErr)
+			if notExist || notNS {
+				logging.Debug("Exiting as the network namespace is not available",
 					"func", "cmdDel",
 					"netConf.DeviceID", netConf.DeviceID,
-					"args.Netns", args.Netns)
+					"args.Netns", args.Netns,
+					"reason", err.Error())
 				return nil
 			}
 


### PR DESCRIPTION
When a netns bind mount gets corrupted — e.g. a non-recursive bind mount of /run/netns strips the nsfs submounts due to shared mount propagation — statfs() returns TMPFS_MAGIC (0x01021994) instead of NSFS_MAGIC. In this case ns.GetNS() returns NSPathNotNSErr, but CmdDel only handles NSPathNotExistErr. The unhandled error causes CmdDel to fail, which makes CRI-O retry teardown in a loop. The pod stays stuck and the sriov-device-plugin keeps allocating the same VF to new sandbox attempts that all fail with "LoadConf(): VF pci addr is required".

Treat NSPathNotNSErr the same as NSPathNotExistErr: the netns is not usable, so return success and let CRI-O proceed with cleanup. The VF cannot be moved back via ReleaseVF (the netns is inaccessible), but it will be recovered by the kernel once all references to the dead netns are released.