### PR TITLE
OCPBUGS-113488: Remove s390x VLAN protocol workaround

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -3,7 +3,6 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"runtime"
 
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/vishvananda/netlink"
@@ -15,14 +14,7 @@ const (
 )
 
 // VlanProtoInt maps VLAN protocol strings to their integer values
-// TODO: Temporary workaround for netlink bug on big-endian systems.
-// Remove once netlink is updated to a version containing https://github.com/vishvananda/netlink/pull/1155
-var VlanProtoInt = func() map[string]int {
-	if runtime.GOARCH == "s390x" {
-		return map[string]int{Proto8021q: 0x81, Proto8021ad: 0xa888}
-	}
-	return map[string]int{Proto8021q: 0x8100, Proto8021ad: 0x88a8}
-}()
+var VlanProtoInt = map[string]int{Proto8021q: 0x8100, Proto8021ad: 0x88a8}
 
 // VfState represents the state of the VF
 type VfState struct {


### PR DESCRIPTION
The workaround compensated for netlink unconditionally byte-swapping the VLAN protocol in LinkSetVfVlanQosProto(), which produced the wrong value on big-endian systems:

    VlanProto: (uint16(proto)>>8)&0xFF | (uint16(proto)&0xFF)<<8

vishvananda/netlink#1155 replaced that with nl.Swap16(), which is a no-op on big-endian:

    func Swap16(i uint16) uint16 {
        if cpu.IsBigEndian {
            return i
        }
        return (i&0xff00)>>8 | (i&0xff)<<8
    }

That fix is present in the netlink version currently pinned in go.mod (v1.3.2-0.20260629151558-4e35dc940f49, link_linux.go:706), so the pre-swapped s390x values are now passed through unchanged and end up incorrect on the wire. Drop the workaround and use the architecture-independent protocol values on all platforms.

Signed-off-by: Ashok Pariya <ashok.pariya@ibm.com>

(cherry picked from commit 162b23e8ef6ab189f78381fe312eceaed01fadd0)